### PR TITLE
[fix]parameter bar

### DIFF
--- a/components/Graph.vue
+++ b/components/Graph.vue
@@ -1,6 +1,6 @@
 <template>
-    <div style="margin-bottom: 50px;">
-        <line-chart style="width: 95%;" :chart-data="datacollection" :options="values.options"></line-chart>
+    <div>
+        <line-chart :chart-data="datacollection" :options="values.options"></line-chart>
     </div>
 </template>
  
@@ -31,60 +31,7 @@ export default {
           labels: this.values.x,
           datasets: this.values.y
         }
-        // this.datacollection = {
-        //   labels: [this.getRandomInt(), this.getRandomInt()],
-        //   datasets: [
-        //     {
-        //       label: 'Test Data2',
-        //       backgroundColor: 'rgba(255, 100, 130, 0.2)',
-        //       data: [this.getRandomInt(), this.getRandomInt(), this.getRandomInt()]
-        //     }, {
-        //       label: 'Test Data2',
-        //       backgroundColor: 'rgba(100, 130, 255, 0.2)',
-        //       data: [this.getRandomInt(), this.getRandomInt(), this.getRandomInt()]
-        //     }
-        //     , {
-        //       label: 'Test Data3',
-        //       backgroundColor: 'rgba(130, 255, 100, 0.2)',
-        //       data: [this.getRandomInt(), this.getRandomInt(), this.getRandomInt()]
-        //     }
-        //   ]
-        // }
       }
     }
 };
-// import { ChartData, ChartOptions } from "chart.js";
-// import ChartLine from "~/components/ChartLine.vue";
-// import ChartBar from "~/components/ChartBar.vue";
-
-// export default {
-//   components: {
-//     ChartLine,
-//     ChartBar
-//   },
-//   props: {
-//     values: {
-//       type: Object,
-//       default: null
-//     }
-//   },
-//   data: () => {
-//     return {
-//         chartOptions: {
-//             maintainAspectRatio: false
-//         },
-//         chartStyles: {
-//             height: "100%",
-//             width: "100%"
-//         }
-//     }
-//   }
-// }
 </script>
-
-<style>
-  .small {
-    max-width: 600px;
-    margin:  150px auto;
-  }
-</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,20 +8,21 @@
         <img src="~/assets/fig1.png" width="100%"/>
         <br>
         <img src="~/assets/fig2.png" width="100%"/>
-      </div>
+      </div> 
       <Equation style="font-size: 4vh;"/>
       <vs-row>
         <vs-col vs-type="flex" vs-justify="center" vs-align="center" vs-lg="6" vs-sm="6" vs-xs="12">
-          <Graph :values="firstGraphData"/>
+          <Graph :values="firstGraphData" style="width:94%;"/>
         </vs-col>
         <vs-col vs-type="flex" vs-justify="center" vs-align="center" vs-lg="6" vs-sm="6" vs-xs="12">
-          <Graph :values="secondGraphData"/>
+          <Graph :values="secondGraphData" style="width:94%;" />
         </vs-col> 
       </vs-row>
       <vs-row>
         <vs-col vs-type="flex" vs-justify="center" vs-align="center" vs-lg="6" vs-sm="6" vs-xs="12">
-          <div style="margin:auto 50px;text-align: center;">
-            <h3 style="margin-bottom:-12px;">u0 = {{Math.floor(u0*100)/100}}</h3><vs-slider :max="U0_MAX*100" v-model="u0Slider"/>
+          <div style="margin:50px auto;text-align: center;">
+            <h3 style="margin-bottom:-12px;">u0 = {{Math.floor(u0*100)/100}}</h3>
+            <vs-slider :max="U0_MAX*100" v-model="u0Slider"/>
             <h3 style="margin-bottom:-12px;margin-top:25px;">v0 = {{Math.floor(v0*100)/100}}</h3><vs-slider :max="V0_MAX*100"  v-model="v0Slider"/>
             <h3 style="margin-bottom:-12px;margin-top:25px;">I1 = {{Math.floor(I1*100)/100}}</h3><vs-slider :max="I1_MAX*100" v-model="I1Slider"/>
             <h3 style="margin-bottom:-12px;margin-top:25px;">I2 = {{Math.floor(I2*100)/100}}</h3><vs-slider :max="I2_MAX*100" v-model="I2Slider"/>


### PR DESCRIPTION
スマホ版で左右にコンテンツがはみ出す不具合を修正。パラメタの調節バーのdivのmarginが誤って左右にかかっていたので上下に修正。